### PR TITLE
fix: set validating webhook failure policy ignore

### DIFF
--- a/operators/kong-gateway-operator/v0.0.1/manifests/kong-gateway-operator.clusterserviceversion.yaml
+++ b/operators/kong-gateway-operator/v0.0.1/manifests/kong-gateway-operator.clusterserviceversion.yaml
@@ -825,6 +825,7 @@ spec:
     - v1beta1
     containerPort: 443
     deploymentName: gateway-operator-controller-manager
+    failurePolicy: Ignore
     generateName: gateway-operator-validation.konghq.com
     rules:
     - apiGroups:


### PR DESCRIPTION
- Rename operator CSV to `kong-gateway-operator.clusterserviceversion.yaml`
- Set webhook failure policy ignore.