### PR TITLE
fix: add Integration & Delivery category

### DIFF
--- a/operators/kong-gateway-operator/v0.0.1/manifests/kong-gateway-operator.clusterserviceversion.yaml
+++ b/operators/kong-gateway-operator/v0.0.1/manifests/kong-gateway-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    categories: Networking
+    categories: Networking,Integration & Delivery
     description: Kong Operator for Kubernetes
     repository: https://github.com/Kong/gateway-operator
     operators.operatorframework.io/builder: operator-sdk-v1.23.0


### PR DESCRIPTION
Seems like other API gateways are also in `Integration & Delivery` category. That has an impact on which tab operator is visible for installation. 

I have tried adding that in the gateway operator repo CSV, but it gets removed after bundle generation.